### PR TITLE
Recursive next page

### DIFF
--- a/clsearch.py
+++ b/clsearch.py
@@ -163,7 +163,7 @@ def get_search_strings(urls) -> list:
     return strings
 
 
-def scrape_link(link, delay, get_next_page=True):
+def scrape_link(link, delay, get_next_page=False):
 
     listings = []
 
@@ -212,20 +212,20 @@ def scrape_link(link, delay, get_next_page=True):
     if get_next_page and meta.find("link", rel="next"):
         if meta.find("link", rel="next"):
             nextpage = meta.find("link", rel="next").get("href")
-            for listing in scrape_link(nextpage, delay, get_next_page=True):
+            for listing in scrape_link(nextpage, delay, get_next_page):
                 listings.append(listing)
 
     return listings
 
 
-def scrape_and_log_results(cities, parameters, delay=0) -> list:
+def scrape_and_log_results(cities, parameters, settings) -> list:
 
     scraped_results = []
 
     for string in parameters:
         for city in cities:
             searchurl = str("https://" + city + ".craigslist.org" + string)
-            for search_results in scrape_link(searchurl, delay, get_next_page=True):
+            for search_results in scrape_link(searchurl, settings.search_delay, settings.scrape_next):
                 scraped_results.append(search_results)
 
     with open('results/results.yaml', 'w+') as outfile:
@@ -299,7 +299,7 @@ def print_scrape_overview(searchstrings, cities, settings) -> None:
     print(*cc, sep="\n")
 
     start = time.time()
-    results = scrape_and_log_results(cities, searchstrings, settings.search_delay)
+    results = scrape_and_log_results(cities, searchstrings, settings)
     end = time.time()
 
     print("\nEXECUTING THESE " + str(len(searchstrings)*len(cities)) + " SCRAPES RETURNS " + str(len(results)) + " RESULTS IN " + str(int(end) - int(start)) + " SECONDS.")
@@ -336,7 +336,7 @@ def searcher():
         for state in states:
             for city in get_citycodes_from_state(state, settings.rosetta_path):        # import list of states from settings
                 cities.append(city)     # append to list of cities
-    cities = list(set(cities))      # remove duplicates from cities list
+    cities = list(set(cities))          # remove duplicates from cities list
 
     searchstrings = get_search_strings(settings.search_urls)    # import search URLs from settings
 
@@ -344,7 +344,7 @@ def searcher():
 
     # This loop is the meat of the program
     while True:
-        newresults = scrape_and_log_results(cities, searchstrings, settings.search_delay)
+        newresults = scrape_and_log_results(cities, searchstrings, settings)
 
         if oldresults:
             notify_if_changed(newresults, oldresults, settings)

--- a/clsearch.py
+++ b/clsearch.py
@@ -212,17 +212,21 @@ def scrape_link(link, delay, get_next_page=True):
     if get_next_page and meta.find("link", rel="next"):
         if meta.find("link", rel="next"):
             nextpage = meta.find("link", rel="next").get("href")
-            listings.append(scrape_link(nextpage, delay, get_next_page=True))
+            for listing in scrape_link(nextpage, delay, get_next_page=True):
+                listings.append(listing)
 
     return listings
 
 
 def scrape_and_log_results(cities, parameters, delay=0) -> list:
 
+    scraped_results = []
+
     for string in parameters:
         for city in cities:
             searchurl = str("https://" + city + ".craigslist.org" + string)
-            scraped_results = scrape_link(searchurl, delay, get_next_page=True)
+            for search_results in scrape_link(searchurl, delay, get_next_page=True):
+                scraped_results.append(search_results)
 
     with open('results/results.yaml', 'w+') as outfile:
         yaml.dump(scraped_results, outfile, default_flow_style=False)
@@ -295,10 +299,10 @@ def print_scrape_overview(searchstrings, cities, settings) -> None:
     print(*cc, sep="\n")
 
     start = time.time()
-    scrape_and_log_results(cities, searchstrings, settings.search_delay)
+    results = scrape_and_log_results(cities, searchstrings, settings.search_delay)
     end = time.time()
 
-    print("\nEXECUTING THESE " + str(len(searchstrings)*len(cities)) + " SCRAPES TAKES " + str(int(end) - int(start)) + " SECONDS.")
+    print("\nEXECUTING THESE " + str(len(searchstrings)*len(cities)) + " SCRAPES RETURNS " + str(len(results)) + " RESULTS IN " + str(int(end) - int(start)) + " SECONDS.")
 
 
 def searcher():

--- a/etc/settings.yaml
+++ b/etc/settings.yaml
@@ -19,12 +19,12 @@ Search Parameters:
     - personToEmailResults2@gmail.com
   cities:             # cities to run searchURLs over (concatenated with states)
     - Dallas
-    #- Jacksonville
-    #- colorado springs
+    - Jacksonville
+    - colorado springs
   states:             # states to run searchURLs over (concatenated with cities)
-    #- kansas
-    #- Texas
+    - kansas
+    - Texas
   searchURLs:         # Craislist URLs to search. See best practices in readme.md for creating effective searches
     - https://dallas.craigslist.org/d/for-sale/search/sss?query=honda%20civic
-    #- https://dallas.craigslist.org/d/cars-trucks/search/cta?max_price=25000&min_price=1000&query=miata%20club%202016%7C2017%7C2018%7C2019%7C2020%7C2021&sort=date
-    #- https://dallas.craigslist.org/d/cars-trucks-by-owner/search/cto?min_price=0&query=s2000%7Cs2k%202000%7C2001%7C2002%7C2003%7C2004%7C2005%7C2006%7C2007%7C2008&sort=date
+    - https://dallas.craigslist.org/d/cars-trucks/search/cta?max_price=25000&min_price=1000&query=miata%20club%202016%7C2017%7C2018%7C2019%7C2020%7C2021&sort=date
+    - https://dallas.craigslist.org/d/cars-trucks-by-owner/search/cto?min_price=0&query=s2000%7Cs2k%202000%7C2001%7C2002%7C2003%7C2004%7C2005%7C2006%7C2007%7C2008&sort=date

--- a/etc/settings.yaml
+++ b/etc/settings.yaml
@@ -1,4 +1,4 @@
-SMTP Client:          #see readme.md for info on SMTP client setup
+SMTP Client:                # see readme.md for info on SMTP client setup
   address : yourSMTPemail@gmail.com
   password : uniquePW123!
   send test : False
@@ -8,23 +8,24 @@ App Settings:
   log results : True
   results path : results/results.yaml
   verbose : True
-  search delay : .1    #time between CL queries, in seconds
+  search delay : .1         # time between CL queries, in seconds
 
 Search Parameters:
-  run : True           #does nothing rn
-  openbrowser : True   #opens new listings in chrome
-  notifyemail : False   #sends email from SMTP client to email recipients (only if SMTP server is set up)
+  run : True                # does nothing rn
+  openbrowser : True        # opens new listings in chrome
+  notifyemail : False       # sends email from SMTP client to email recipients (only if SMTP server is set up)
+  scrape all pages : False  # uses the "next page" button to retrieve all search results, when applicable
   email:
     - personToEmailResults1@gmail.com
     - personToEmailResults2@gmail.com
-  cities:             # cities to run searchURLs over (concatenated with states)
+  cities:                   # cities to run searchURLs over (concatenated with states)
     - Dallas
     - Jacksonville
     - colorado springs
-  states:             # states to run searchURLs over (concatenated with cities)
+  states:                   # states to run searchURLs over (concatenated with cities)
     - kansas
     - Texas
-  searchURLs:         # Craislist URLs to search. See best practices in readme.md for creating effective searches
+  searchURLs:               # Craislist URLs to search. See best practices in readme.md for creating effective searches
     - https://dallas.craigslist.org/d/for-sale/search/sss?query=honda%20civic
     - https://dallas.craigslist.org/d/cars-trucks/search/cta?max_price=25000&min_price=1000&query=miata%20club%202016%7C2017%7C2018%7C2019%7C2020%7C2021&sort=date
     - https://dallas.craigslist.org/d/cars-trucks-by-owner/search/cto?min_price=0&query=s2000%7Cs2k%202000%7C2001%7C2002%7C2003%7C2004%7C2005%7C2006%7C2007%7C2008&sort=date

--- a/etc/settings.yaml
+++ b/etc/settings.yaml
@@ -18,11 +18,13 @@ Search Parameters:
     - personToEmailResults1@gmail.com
     - personToEmailResults2@gmail.com
   cities:             # cities to run searchURLs over (concatenated with states)
-    - Jacksonville
-    - colorado springs
+    - Dallas
+    #- Jacksonville
+    #- colorado springs
   states:             # states to run searchURLs over (concatenated with cities)
-    - kansas
-    - Texas
-  searchURLs:         #make sure these searches have a min price set (even if it's 0) - listings with no price set will cause a runtime error at the moment.
-    - https://dallas.craigslist.org/d/cars-trucks/search/cta?max_price=25000&min_price=1000&query=miata%20club%202016%7C2017%7C2018%7C2019%7C2020%7C2021&sort=date
-    - https://dallas.craigslist.org/d/cars-trucks-by-owner/search/cto?min_price=0&query=s2000%7Cs2k%202000%7C2001%7C2002%7C2003%7C2004%7C2005%7C2006%7C2007%7C2008&sort=date
+    #- kansas
+    #- Texas
+  searchURLs:         # Craislist URLs to search. See best practices in readme.md for creating effective searches
+    - https://dallas.craigslist.org/d/for-sale/search/sss?query=honda%20civic
+    #- https://dallas.craigslist.org/d/cars-trucks/search/cta?max_price=25000&min_price=1000&query=miata%20club%202016%7C2017%7C2018%7C2019%7C2020%7C2021&sort=date
+    #- https://dallas.craigslist.org/d/cars-trucks-by-owner/search/cto?min_price=0&query=s2000%7Cs2k%202000%7C2001%7C2002%7C2003%7C2004%7C2005%7C2006%7C2007%7C2008&sort=date

--- a/lib/settingsparse.py
+++ b/lib/settingsparse.py
@@ -17,6 +17,7 @@ class SettingsParser:
     run = True
     open_browser = True
     notify_email = True
+    scrape_next = False
     email_recipients = []
     cities = []
     states = []
@@ -50,6 +51,7 @@ class SettingsParser:
         self.run = search_parameters['run']
         self.open_browser = search_parameters['openbrowser']
         self.notify_email = search_parameters['notifyemail']
+        self.scrape_next = search_parameters['scrape all pages']
         self.email_recipients = search_parameters['email']
         self.cities = search_parameters['cities']
         self.states = search_parameters['states']

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,6 @@ Contains settings and search configurations for running the application.
     * Set up your full search with filters on craigslist.org and copy-paste the URL into these bulleted-fields
     * BEST PRACTICE: Use search narrowing methods, listed here to block out 'noise' in your search: https://www.craigslist.org/about/help/search
     * BEST PRACTICE: Sort by 'newest' rather than relevant. We don't dig past the first page of results, so make sure the latest results are on top. 
-    * BEST PRACTICE: Set a min price of $0, rather than leaving it blank. Results without a price field make this program very sad.
 
 **./etc/rosetta.yaml**
 


### PR DESCRIPTION
Added functionality to allow craigslist scrapes to access "next page" link, when the appropriate flag is set in settings.yaml. This is done recursively and the architecture doesn't cause any additional overhead compared to current main branch when flag is set to False. 

This branch also breaks out a "scrape link" function from scrape and log results in clsearch.py. and adds a few fixes for scraped fields that are optional on posts.

Finally, I give a total count of scraped listings in print_scrape_overview()